### PR TITLE
Update package.json to support CaludeV3 and Mixtral

### DIFF
--- a/function/package.json
+++ b/function/package.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
-    "@aws-sdk/client-bedrock-runtime": "^3.438.0",
-    "@aws-sdk/credential-provider-node": "^3.438.0",
-    "@aws-sdk/types": "^3.433.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.515.0",
+    "@aws-sdk/credential-provider-node": "^3.515.0",
+    "@aws-sdk/types": "^3.515.0",
     "@smithy/eventstream-codec": "^2.0.12",
     "@smithy/protocol-http": "^3.0.8",
     "@smithy/signature-v4": "^2.0.12",
     "@smithy/util-utf8": "^2.0.0",
-    "langchain": "^0.0.177",
+    "langchain": "^0.1.19",
     "vectordb": "^0.1.19",
     "@lancedb/vectordb-linux-x64-gnu": "^0.3.5"
   }


### PR DESCRIPTION
bumping up dependencies so that we can use Bedrock's integrations of Anthropic Claude v3 (Haiku and Sonnet) + Mistral's Mixtral